### PR TITLE
Add #payload in Exceptions Class to give client ability to see full error response

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
---format documentation
 --color
 --require spec_helper

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,9 @@ Style/Documentation:
 Style/FrozenStringLiteralComment:
   Enabled: false
 
+Style/MultilineBlockChain:
+  Enabled: false
+
 Metrics/AbcSize:
   Max: 30
 

--- a/lib/xendit_api/api/disbursement.rb
+++ b/lib/xendit_api/api/disbursement.rb
@@ -14,7 +14,7 @@ module XenditApi
       def find_by_external_id(external_id)
         response = client.get("#{self.class::PATH}/?external_id=#{external_id}", {})
 
-        XenditApi::Model::Disbursement.new(response[0])
+        XenditApi::Model::Disbursement.new(response[0].merge(payload: response.to_json))
       end
     end
   end

--- a/lib/xendit_api/errors.rb
+++ b/lib/xendit_api/errors.rb
@@ -1,6 +1,15 @@
 module XenditApi
   module Errors
-    class ResponseError < StandardError; end
+    class ResponseError < StandardError
+      attr_reader :payload
+
+      def initialize(message, payload = nil)
+        @message = message
+        @payload = payload
+        super(@message)
+      end
+    end
+
     class ApiValidation < ResponseError; end
     class UnknownError < ResponseError; end
     class ServerError < ResponseError; end

--- a/lib/xendit_api/errors/credit_card.rb
+++ b/lib/xendit_api/errors/credit_card.rb
@@ -1,7 +1,7 @@
 module XenditApi
   module Errors
     module CreditCard
-      class ResponseError < StandardError; end
+      class ResponseError < XenditApi::Errors::ResponseError; end
 
       class ChargeError < ResponseError; end
 

--- a/lib/xendit_api/errors/disbursement.rb
+++ b/lib/xendit_api/errors/disbursement.rb
@@ -1,7 +1,7 @@
 module XenditApi
   module Errors
     module Disbursement
-      class Error < StandardError; end
+      class Error < XenditApi::Errors::ResponseError; end
       class DescriptionNotFound < Error; end
       class NotEnoughBalance < Error; end
       class DuplicateTransactionError < Error; end

--- a/lib/xendit_api/errors/ovo.rb
+++ b/lib/xendit_api/errors/ovo.rb
@@ -1,7 +1,7 @@
 module XenditApi
   module Errors
     module OVO
-      class ResponseError < StandardError; end
+      class ResponseError < XenditApi::Errors::ResponseError; end
 
       class PaymentTimeout < ResponseError; end
 

--- a/lib/xendit_api/errors/v1/ewallet.rb
+++ b/lib/xendit_api/errors/v1/ewallet.rb
@@ -2,7 +2,7 @@ module XenditApi
   module Errors
     module V1
       module Ewallet
-        class ResponseError < StandardError; end
+        class ResponseError < XenditApi::Errors::ResponseError; end
 
         class ChannelNotActivated < ResponseError; end
 

--- a/lib/xendit_api/errors/virtual_account.rb
+++ b/lib/xendit_api/errors/virtual_account.rb
@@ -1,7 +1,7 @@
 module XenditApi
   module Errors
     module VirtualAccount
-      class ResponseError < StandardError; end
+      class ResponseError < XenditApi::Errors::ResponseError; end
 
       class CallbackNotFound < ResponseError; end
 

--- a/lib/xendit_api/middleware/handle_response_exception.rb
+++ b/lib/xendit_api/middleware/handle_response_exception.rb
@@ -22,29 +22,29 @@ module XenditApi
 
         case json_response['error_code']
         when 'USER_DID_NOT_AUTHORIZE_THE_PAYMENT'
-          raise XenditApi::Errors::OVO::PaymentTimeout, error_message
+          raise XenditApi::Errors::OVO::PaymentTimeout.new(error_message, json_response)
         when 'DUPLICATE_PAYMENT'
-          raise XenditApi::Errors::OVO::DuplicatePayment, error_message
+          raise XenditApi::Errors::OVO::DuplicatePayment.new(error_message, json_response)
         when 'SENDING_TRANSACTION_ERROR'
-          raise XenditApi::Errors::OVO::SendingRequest, error_message
+          raise XenditApi::Errors::OVO::SendingRequest.new(error_message, json_response)
         when 'USER_DECLINED_THE_TRANSACTION'
-          raise XenditApi::Errors::OVO::TransactionDeclined, error_message
+          raise XenditApi::Errors::OVO::TransactionDeclined.new(error_message, json_response)
         when 'PHONE_NUMBER_NOT_REGISTERED'
-          raise XenditApi::Errors::OVO::PhoneNumberNotRegistered, error_message
+          raise XenditApi::Errors::OVO::PhoneNumberNotRegistered.new(error_message, json_response)
         when 'EWALLET_APP_UNREACHABLE'
-          raise XenditApi::Errors::OVO::EwalletAppUnreacable, error_message
+          raise XenditApi::Errors::OVO::EwalletAppUnreacable.new(error_message, json_response)
         when 'EXTERNAL_ERROR'
-          raise XenditApi::Errors::OVO::ExternalError, error_message
+          raise XenditApi::Errors::OVO::ExternalError.new(error_message, json_response)
         when 'PAYMENT_NOT_FOUND_ERROR'
-          raise XenditApi::Errors::OVO::PaymentNotFound, error_message
+          raise XenditApi::Errors::OVO::PaymentNotFound.new(error_message, json_response)
         when 'CHANNEL_NOT_ACTIVATED'
           raise XenditApi::Errors::V1::Ewallet::ChannelNotActivated.new(error_message, json_response)
         when 'CHANNEL_UNAVAILABLE'
-          raise XenditApi::Errors::V1::Ewallet::ChannelUnavailable, error_message
+          raise XenditApi::Errors::V1::Ewallet::ChannelUnavailable.new(error_message, json_response)
         when 'DUPLICATE_ERROR'
-          raise XenditApi::Errors::V1::Ewallet::DuplicateError, error_message
+          raise XenditApi::Errors::V1::Ewallet::DuplicateError.new(error_message, json_response)
         when 'DATA_NOT_FOUND'
-          raise XenditApi::Errors::V1::Ewallet::DataNotFound, error_message
+          raise XenditApi::Errors::V1::Ewallet::DataNotFound.new(error_message, json_response)
         when 'API_VALIDATION_ERROR'
           # In this exception with custom the title since, the message from
           # could returns arrays (see the payload for the full messages)
@@ -100,9 +100,9 @@ module XenditApi
         when 'BANK_CODE_NOT_SUPPORTED_ERROR'
           raise XenditApi::Errors::Disbursement::BankCodeNotSupported.new(error_message, json_response)
         when 'SERVER_ERROR'
-          raise XenditApi::Errors::ServerError, error_message
+          raise XenditApi::Errors::ServerError.new(error_message, json_response)
         else
-          raise XenditApi::Errors::UnknownError, error_message
+          raise XenditApi::Errors::UnknownError.new(error_message, json_response)
         end
       end
       # rubocop:enable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity, Metrics/AbcSize, Metrics/MethodLength

--- a/lib/xendit_api/middleware/handle_response_exception.rb
+++ b/lib/xendit_api/middleware/handle_response_exception.rb
@@ -38,7 +38,7 @@ module XenditApi
         when 'PAYMENT_NOT_FOUND_ERROR'
           raise XenditApi::Errors::OVO::PaymentNotFound, error_message
         when 'CHANNEL_NOT_ACTIVATED'
-          raise XenditApi::Errors::V1::Ewallet::ChannelNotActivated, error_message
+          raise XenditApi::Errors::V1::Ewallet::ChannelNotActivated.new(error_message, json_response)
         when 'CHANNEL_UNAVAILABLE'
           raise XenditApi::Errors::V1::Ewallet::ChannelUnavailable, error_message
         when 'DUPLICATE_ERROR'
@@ -46,7 +46,9 @@ module XenditApi
         when 'DATA_NOT_FOUND'
           raise XenditApi::Errors::V1::Ewallet::DataNotFound, error_message
         when 'API_VALIDATION_ERROR'
-          raise XenditApi::Errors::ApiValidation, error_message
+          # In this exception with custom the title since, the message from
+          # could returns arrays (see the payload for the full messages)
+          raise XenditApi::Errors::ApiValidation.new('Validation error', json_response)
         when 'CALLBACK_VIRTUAL_ACCOUNT_NOT_FOUND_ERROR'
           raise XenditApi::Errors::VirtualAccount::CallbackNotFound, error_message
         when 'BANK_NOT_SUPPORTED_ERROR'

--- a/lib/xendit_api/middleware/handle_response_exception.rb
+++ b/lib/xendit_api/middleware/handle_response_exception.rb
@@ -82,19 +82,19 @@ module XenditApi
           raise XenditApi::Errors::CreditCard::ChargeError, error_message
         # disbursements
         when 'DISBURSEMENT_DESCRIPTION_NOT_FOUND_ERROR'
-          raise XenditApi::Errors::Disbursement::DescriptionNotFound, error_message
+          raise XenditApi::Errors::Disbursement::DescriptionNotFound.new(error_message, json_response)
         when 'DIRECT_DISBURSEMENT_BALANCE_INSUFFICIENT_ERROR'
-          raise XenditApi::Errors::Disbursement::NotEnoughBalance, error_message
+          raise XenditApi::Errors::Disbursement::NotEnoughBalance.new(error_message, json_response)
         when 'DIRECT_DISBURSEMENT_NOT_FOUND_ERROR'
-          raise XenditApi::Errors::Disbursement::DirectDisbursementNotFound, error_message
+          raise XenditApi::Errors::Disbursement::DirectDisbursementNotFound.new(error_message, json_response)
         when 'DUPLICATE_TRANSACTION_ERROR'
-          raise XenditApi::Errors::Disbursement::DuplicateTransactionError, error_message
+          raise XenditApi::Errors::Disbursement::DuplicateTransactionError.new(error_message, json_response)
         when 'RECIPIENT_ACCOUNT_NUMBER_ERROR'
-          raise XenditApi::Errors::Disbursement::RecipientAccountNumberError, error_message
+          raise XenditApi::Errors::Disbursement::RecipientAccountNumberError.new(error_message, json_response)
         when 'RECIPIENT_AMOUNT_ERROR'
-          raise XenditApi::Errors::Disbursement::RecipientAmountError, error_message
+          raise XenditApi::Errors::Disbursement::RecipientAmountError.new(error_message, json_response)
         when 'MAXIMUM_TRANSFER_LIMIT_ERROR'
-          raise XenditApi::Errors::Disbursement::MaximumTransferLimitError, error_message
+          raise XenditApi::Errors::Disbursement::MaximumTransferLimitError.new(error_message, json_response)
         when 'BANK_CODE_NOT_SUPPORTED_ERROR'
           raise XenditApi::Errors::Disbursement::BankCodeNotSupported.new(error_message, json_response)
         when 'SERVER_ERROR'

--- a/lib/xendit_api/middleware/handle_response_exception.rb
+++ b/lib/xendit_api/middleware/handle_response_exception.rb
@@ -50,35 +50,35 @@ module XenditApi
           # could returns arrays (see the payload for the full messages)
           raise XenditApi::Errors::ApiValidation.new('Validation error', json_response)
         when 'CALLBACK_VIRTUAL_ACCOUNT_NOT_FOUND_ERROR'
-          raise XenditApi::Errors::VirtualAccount::CallbackNotFound, error_message
+          raise XenditApi::Errors::VirtualAccount::CallbackNotFound.new(error_message, json_response)
         when 'BANK_NOT_SUPPORTED_ERROR'
-          raise XenditApi::Errors::VirtualAccount::BankNotSupported, error_message
+          raise XenditApi::Errors::VirtualAccount::BankNotSupported.new(error_message, json_response)
         when 'INVALID_JSON_FORMAT'
-          raise XenditApi::Errors::VirtualAccount::InvalidJsonFormat, error_message
+          raise XenditApi::Errors::VirtualAccount::InvalidJsonFormat.new(error_message, json_response)
         when 'VIRTUAL_ACCOUNT_NUMBER_OUTSIDE_RANGE'
-          raise XenditApi::Errors::VirtualAccount::VirtualAccountNumberOutsideRange, error_message
+          raise XenditApi::Errors::VirtualAccount::VirtualAccountNumberOutsideRange.new(error_message, json_response)
         when 'EXPIRATION_DATE_NOT_SUPPORTED_ERROR'
-          raise XenditApi::Errors::VirtualAccount::ExpirationDateNotSupported, error_message
+          raise XenditApi::Errors::VirtualAccount::ExpirationDateNotSupported.new(error_message, json_response)
         when 'EXPIRATION_DATE_INVALID_ERROR'
-          raise XenditApi::Errors::VirtualAccount::ExpirationInvalid, error_message
+          raise XenditApi::Errors::VirtualAccount::ExpirationInvalid.new(error_message, json_response)
         when 'SUGGESTED_AMOUNT_NOT_SUPPORTED_ERROR'
-          raise XenditApi::Errors::VirtualAccount::SuggestedAmountNotSupported, error_message
+          raise XenditApi::Errors::VirtualAccount::SuggestedAmountNotSupported.new(error_message, json_response)
         when 'EXPECTED_AMOUNT_REQUIRED_ERROR'
-          raise XenditApi::Errors::VirtualAccount::ExpectedAmountRequired, error_message
+          raise XenditApi::Errors::VirtualAccount::ExpectedAmountRequired.new(error_message, json_response)
         when 'CLOSED_VA_NOT_SUPPORTED_ERROR'
-          raise XenditApi::Errors::VirtualAccount::ClosedVaNotSupported, error_message
+          raise XenditApi::Errors::VirtualAccount::ClosedVaNotSupported.new(error_message, json_response)
         when 'DUPLICATE_CALLBACK_VIRTUAL_ACCOUNT_ERROR'
-          raise XenditApi::Errors::VirtualAccount::DuplicateCallbackVirtualAccount, error_message
+          raise XenditApi::Errors::VirtualAccount::DuplicateCallbackVirtualAccount.new(error_message, json_response)
         when 'MAXIMUM_EXPECTED_AMOUNT_ERROR'
-          raise XenditApi::Errors::VirtualAccount::MaximumExpectedAmount, error_message
+          raise XenditApi::Errors::VirtualAccount::MaximumExpectedAmount.new(error_message, json_response)
         when 'CALLBACK_VIRTUAL_ACCOUNT_NAME_NOT_ALLOWED_ERROR'
-          raise XenditApi::Errors::VirtualAccount::CallbackVirtualAccountNameNotAllowed, error_message
+          raise XenditApi::Errors::VirtualAccount::CallbackVirtualAccountNameNotAllowed.new(error_message, json_response)
         when 'DESCRIPTION_NOT_SUPPORTED_ERROR'
-          raise XenditApi::Errors::VirtualAccount::DescriptionNotSupported, error_message
+          raise XenditApi::Errors::VirtualAccount::DescriptionNotSupported.new(error_message, json_response)
         when 'MINIMUM_EXPECTED_AMOUNT_ERROR'
-          raise XenditApi::Errors::VirtualAccount::MinimumExpectedAmount, error_message
+          raise XenditApi::Errors::VirtualAccount::MinimumExpectedAmount.new(error_message, json_response)
         when 'REQUEST_FORBIDDEN_ERROR'
-          raise XenditApi::Errors::VirtualAccount::RequestForbidden, error_message
+          raise XenditApi::Errors::VirtualAccount::RequestForbidden.new(error_message, json_response)
         # credit cards
         when 'INVALID_TOKEN_ID_ERROR'
           raise XenditApi::Errors::CreditCard::ChargeError.new(error_message, json_response)

--- a/lib/xendit_api/middleware/handle_response_exception.rb
+++ b/lib/xendit_api/middleware/handle_response_exception.rb
@@ -79,7 +79,7 @@ module XenditApi
           raise XenditApi::Errors::VirtualAccount::RequestForbidden, error_message
         # credit cards
         when 'INVALID_TOKEN_ID_ERROR'
-          raise XenditApi::Errors::CreditCard::ChargeError, error_message
+          raise XenditApi::Errors::CreditCard::ChargeError.new(error_message, json_response)
         # disbursements
         when 'DISBURSEMENT_DESCRIPTION_NOT_FOUND_ERROR'
           raise XenditApi::Errors::Disbursement::DescriptionNotFound.new(error_message, json_response)

--- a/lib/xendit_api/middleware/handle_response_exception.rb
+++ b/lib/xendit_api/middleware/handle_response_exception.rb
@@ -96,7 +96,7 @@ module XenditApi
         when 'MAXIMUM_TRANSFER_LIMIT_ERROR'
           raise XenditApi::Errors::Disbursement::MaximumTransferLimitError, error_message
         when 'BANK_CODE_NOT_SUPPORTED_ERROR'
-          raise XenditApi::Errors::Disbursement::BankCodeNotSupported, error_message
+          raise XenditApi::Errors::Disbursement::BankCodeNotSupported.new(error_message, json_response)
         when 'SERVER_ERROR'
           raise XenditApi::Errors::ServerError, error_message
         else

--- a/lib/xendit_api/model/base.rb
+++ b/lib/xendit_api/model/base.rb
@@ -17,9 +17,10 @@ module XenditApi
         end
       end
 
+      # Private: Set attribute with only defined resource attribute
       def assign_attribute(key, value)
         setter = :"#{key}="
-        public_send(setter, value)
+        public_send(setter, value) if respond_to?(setter)
       end
     end
   end

--- a/lib/xendit_api/model/disbursement.rb
+++ b/lib/xendit_api/model/disbursement.rb
@@ -10,6 +10,7 @@ module XenditApi
                     :account_holder_name,
                     :description,
                     :disbursement_description,
+                    :is_instant,
                     :status,
                     :id,
                     :email_to,

--- a/spec/vcr/xendit/credit_card/error_charge.yml
+++ b/spec/vcr/xendit/credit_card/error_charge.yml
@@ -1,0 +1,53 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.xendit.co/credit_card_charges
+    body:
+      encoding: UTF-8
+      string: '{"token":"dc3404a5ceb56650f493f076a1b46c01","card_cvv":"123","external_id":"d45bf4d4fdef9231c5b37a3d4ac80777"}'
+    headers:
+      Authorization:
+      - Basic <AUTH KEY>
+      User-Agent:
+      - Faraday v1.3.0
+      Content-Type:
+      - application/json
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 31 Jul 2021 09:04:24 GMT
+      Etag:
+      - W/"f9-C0aGw8vHeuCb1tJtBUBe5PNjh8M"
+      Server:
+      - nginx
+      X-Powered-By:
+      - Express
+      Connection:
+      - keep-alive
+      Set-Cookie:
+      - incap_ses_1113_2182539=MUQCEh8UBntHxrJ9BSxyDxgSBWEAAAAAj7gbeNf33gfJzuwbGEfOpQ==;
+        path=/; Domain=.xendit.co
+      - nlbi_2182539=ns01FunAzGzc0TMZjjCKbQAAAACcKXQVnC0C9xKrVXFPnUvt; path=/; Domain=.xendit.co
+      - visid_incap_2182539=9ljfqgYSRim2un7zRrkGvBcSBWEAAAAAQUIPAAAAAAA7jsIziyHeSvW5cAHNtDbM;
+        expires=Sun, 31 Jul 2022 09:04:13 GMT; HttpOnly; path=/; Domain=.xendit.co
+      X-Cdn:
+      - Imperva
+      Transfer-Encoding:
+      - chunked
+      X-Iinfo:
+      - 14-6886500-6628387 pNYN RT(1627722263738 58) q(0 0 0 1) r(5 5) U6
+    body:
+      encoding: ASCII-8BIT
+      string: '{"error_code":"INVALID_TOKEN_ID_ERROR","message":"Invalid charge"}'
+  recorded_at: Sat, 31 Jul 2021 09:04:24 GMT
+recorded_with: VCR 6.0.0

--- a/spec/vcr/xendit/disbursement/create/disbursement_description_not_found_error.yml
+++ b/spec/vcr/xendit/disbursement/create/disbursement_description_not_found_error.yml
@@ -57,7 +57,7 @@ http_interactions:
       - 4-23730259-23686671 pNYN RT(1587089899738 16) q(0 0 0 -1) r(5 5) U6
     body:
       encoding: ASCII-8BIT
-      string: '{"error_code":"DISBURSEMENT_DESCRIPTION_NOT_FOUND_ERROR","message":"create manual the vcr"}'
+      string: '{"error_code":"DISBURSEMENT_DESCRIPTION_NOT_FOUND_ERROR","message":"Direct disbursement not found"}'
     http_version: 
   recorded_at: Fri, 17 Apr 2020 02:18:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/xendit/disbursement/create/disbursement_not_enough_balance_error.yml
+++ b/spec/vcr/xendit/disbursement/create/disbursement_not_enough_balance_error.yml
@@ -57,7 +57,7 @@ http_interactions:
       - 4-23730259-23686671 pNYN RT(1587089899738 16) q(0 0 0 -1) r(5 5) U6
     body:
       encoding: ASCII-8BIT
-      string: '{"error_code":"DIRECT_DISBURSEMENT_BALANCE_INSUFFICIENT_ERROR","message":"create manual the vcr"}'
+      string: '{"error_code":"DIRECT_DISBURSEMENT_BALANCE_INSUFFICIENT_ERROR","message":"Balance is insufficient"}'
     http_version: 
   recorded_at: Fri, 17 Apr 2020 02:18:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/xendit/disbursement/create/duplicate_transaction_error.yml
+++ b/spec/vcr/xendit/disbursement/create/duplicate_transaction_error.yml
@@ -57,7 +57,7 @@ http_interactions:
       - 4-23730259-23686671 pNYN RT(1587089899738 16) q(0 0 0 -1) r(5 5) U6
     body:
       encoding: ASCII-8BIT
-      string: '{"error_code":"DUPLICATE_TRANSACTION_ERROR","message":"create manual the vcr"}'
+      string: '{"error_code":"DUPLICATE_TRANSACTION_ERROR","message":"Disbursement was duplicated"}'
     http_version: 
   recorded_at: Fri, 17 Apr 2020 02:18:20 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/xendit/disbursement/create/maximum_transfer_limit_error.yml
+++ b/spec/vcr/xendit/disbursement/create/maximum_transfer_limit_error.yml
@@ -57,7 +57,7 @@ http_interactions:
       - 4-23937682-23924889 pNYN RT(1587093878591 14) q(0 0 0 -1) r(5 5) U6
     body:
       encoding: ASCII-8BIT
-      string: '{"error_code":"MAXIMUM_TRANSFER_LIMIT_ERROR","message":"edit vcr manually"}'
+      string: '{"error_code":"MAXIMUM_TRANSFER_LIMIT_ERROR","message":"Maximum transfer limit error"}'
     http_version: 
   recorded_at: Fri, 17 Apr 2020 03:24:39 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/xendit/disbursement/create/recipient_amount_error.yml
+++ b/spec/vcr/xendit/disbursement/create/recipient_amount_error.yml
@@ -57,7 +57,7 @@ http_interactions:
       - 4-23937682-23924889 pNYN RT(1587093878591 14) q(0 0 0 -1) r(5 5) U6
     body:
       encoding: ASCII-8BIT
-      string: '{"error_code":"RECIPIENT_AMOUNT_ERROR","message":"edit vcr manually"}'
+      string: '{"error_code":"RECIPIENT_AMOUNT_ERROR","message":"Recipient amount error"}'
     http_version: 
   recorded_at: Fri, 17 Apr 2020 03:24:39 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr/xendit/disbursement/find_by_external_id/200_ok.yml
+++ b/spec/vcr/xendit/disbursement/find_by_external_id/200_ok.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.xendit.co/disbursements/?external_id=d666
+    uri: https://api.xendit.co/disbursements/?external_id=d28aac6a-03c8-46d0-ac03-43b6278b35eb
     body:
       encoding: US-ASCII
       string: ''
@@ -17,17 +17,17 @@ http_interactions:
       - "*/*"
   response:
     status:
-      code: 404
-      message: Not Found
+      code: 200
+      message: OK
     headers:
       Cache-Control:
       - no-store, no-cache, must-revalidate, proxy-revalidate
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Sat, 31 Jul 2021 05:51:53 GMT
+      - Sat, 31 Jul 2021 05:57:10 GMT
       Etag:
-      - W/"5e-szzl1BgCBV0ooAVARKI1gKwkAWg"
+      - W/"11f-3+UVlkK0pGjl3VvLUb2HwWTIkd4"
       Expires:
       - '0'
       Pragma:
@@ -41,20 +41,20 @@ http_interactions:
       Connection:
       - keep-alive
       Set-Cookie:
-      - incap_ses_1112_2182539=7o+YTyaj/C4YAZ6Bi55uD/jkBGEAAAAAH+rbTo2HxX7Zaaq90YKMWg==;
+      - incap_ses_1112_2182539=39bBPGU75C9XlJ6Bi55uDzbmBGEAAAAA6D0VTWANeEPlvGt+I5JD6Q==;
         path=/; Domain=.xendit.co
-      - nlbi_2182539=Xka4INRAiQnf1q+yjjCKbQAAAABJbhRQc1ogN1sHE9AfJXIh; path=/; Domain=.xendit.co
-      - visid_incap_2182539=YqqY0LpTQGOmcYXLRnlHgPjkBGEAAAAAQUIPAAAAAAD+BokYYudOZzFer6AnJRgI;
+      - nlbi_2182539=ukcfGUnuNVoFm8QgjjCKbQAAAAD0wCeFxH3y27iLXjfI8z0y; path=/; Domain=.xendit.co
+      - visid_incap_2182539=bAGplKaAS2qydNMNG92SmDbmBGEAAAAAQUIPAAAAAACb46wSxmJCu1RBtawhLqt5;
         expires=Sat, 30 Jul 2022 08:08:38 GMT; HttpOnly; path=/; Domain=.xendit.co
       X-Cdn:
       - Imperva
       Transfer-Encoding:
       - chunked
       X-Iinfo:
-      - 11-5687903-5682993 pNYN RT(1627710711991 38) q(0 0 0 0) r(5 5) U16
+      - 5-9823368-9591682 pNYN RT(1627711029689 75) q(0 0 0 -1) r(5 5) U16
     body:
       encoding: ASCII-8BIT
-      string: '{"error_code":"DIRECT_DISBURSEMENT_NOT_FOUND_ERROR","message":"Direct
-        disbursement not found"}'
-  recorded_at: Sat, 31 Jul 2021 05:51:53 GMT
+      string: '[{"status":"COMPLETED","user_id":"596d988e56b5a3c45be75e6e","external_id":"d28aac6a-03c8-46d0-ac03-43b6278b35eb","amount":90000,"bank_code":"BNI","account_holder_name":"Jesse
+        Pinkman","disbursement_description":"Disbursement July 2021","is_instant":true,"id":"6103db4e48f6e8002177468b"}]'
+  recorded_at: Sat, 31 Jul 2021 05:57:11 GMT
 recorded_with: VCR 6.0.0

--- a/spec/xendit_api/api/credit_card_spec.rb
+++ b/spec/xendit_api/api/credit_card_spec.rb
@@ -116,11 +116,30 @@ RSpec.describe XenditApi::Api::CreditCard do
       expect(credit_card_response).to be_instance_of XenditApi::Model::CreditCard
       expect(credit_card_response.status).to eq 'CAPTURED'
     end
+
+    it 'raise expected exception' do
+      VCR.use_cassette('xendit/credit_card/error_charge') do
+        error_payload = { 'error_code' => 'INVALID_TOKEN_ID_ERROR', 'message' => 'Invalid charge' }
+        api_charge = described_class.new(client)
+        params = {
+          token: SecureRandom.hex,
+          card_cvv: '123',
+          external_id: SecureRandom.hex
+        }
+        expect do
+          api_charge.charge(params)
+        end.to raise_error do |error|
+          expect(error).to be_kind_of XenditApi::Errors::CreditCard::ChargeError
+          expect(error.message).to eq 'Invalid charge'
+          expect(error.payload).to eq error_payload
+        end
+      end
+    end
   end
 
   private
 
   def stub_client_post_to(response)
-    allow_any_instance_of(XenditApi::Client).to receive(:post).and_return(response)
+    allow_any_instance_of(Faraday::Connection).to receive(:post).and_return(OpenStruct.new(body: response))
   end
 end

--- a/spec/xendit_api/api/disbursement_spec.rb
+++ b/spec/xendit_api/api/disbursement_spec.rb
@@ -54,6 +54,7 @@ RSpec.describe XenditApi::Api::Disbursement do
       end
 
       it 'raise errors when got DISBURSEMENT_DESCRIPTION_NOT_FOUND_ERROR' do
+        error_payload = { 'error_code' => 'DISBURSEMENT_DESCRIPTION_NOT_FOUND_ERROR', 'message' => 'Direct disbursement not found' }
         VCR.use_cassette('xendit/disbursement/create/disbursement_description_not_found_error') do
           disbursement_api = described_class.new(client)
           expect do
@@ -65,11 +66,16 @@ RSpec.describe XenditApi::Api::Disbursement do
               account_number: '1111111111',
               disbursement_description: nil
             )
-          end.to raise_error XenditApi::Errors::Disbursement::DescriptionNotFound
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::Disbursement::DescriptionNotFound
+            expect(error.message).to eq 'Direct disbursement not found'
+            expect(error.payload).to eq error_payload
+          end
         end
       end
 
       it 'raise errors when got DIRECT_DISBURSEMENT_BALANCE_INSUFFICIENT_ERROR' do
+        error_payload = { 'error_code' => 'DIRECT_DISBURSEMENT_BALANCE_INSUFFICIENT_ERROR', 'message' => 'Balance is insufficient' }
         VCR.use_cassette('xendit/disbursement/create/disbursement_not_enough_balance_error') do
           disbursement_api = described_class.new(client)
           expect do
@@ -81,11 +87,16 @@ RSpec.describe XenditApi::Api::Disbursement do
               account_number: '1111111111',
               disbursement_description: 'sample disbursement'
             )
-          end.to raise_error XenditApi::Errors::Disbursement::NotEnoughBalance
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::Disbursement::NotEnoughBalance
+            expect(error.message).to eq 'Balance is insufficient'
+            expect(error.payload).to eq error_payload
+          end
         end
       end
 
       it 'raise erorrs when got DUPLICATE_TRANSACTION_ERROR' do
+        error_payload = { 'error_code' => 'DUPLICATE_TRANSACTION_ERROR', 'message' => 'Disbursement was duplicated' }
         VCR.use_cassette('xendit/disbursement/create/duplicate_transaction_error') do
           disbursement_api = described_class.new(client)
           expect do
@@ -97,11 +108,16 @@ RSpec.describe XenditApi::Api::Disbursement do
               account_number: '1111111111',
               disbursement_description: 'sample disbursement'
             )
-          end.to raise_error XenditApi::Errors::Disbursement::DuplicateTransactionError
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::Disbursement::DuplicateTransactionError
+            expect(error.message).to eq 'Disbursement was duplicated'
+            expect(error.payload).to eq error_payload
+          end
         end
       end
 
       it 'raise error when got RECIPIENT_ACCOUNT_NUMBER_ERROR' do
+        error_payload = { 'error_code' => 'RECIPIENT_ACCOUNT_NUMBER_ERROR', 'message' => 'BCA account numbers must be 10 digits long' }
         VCR.use_cassette('xendit/disbursement/create/recipient_account_number_error') do
           disbursement_api = described_class.new(client)
           expect do
@@ -113,11 +129,16 @@ RSpec.describe XenditApi::Api::Disbursement do
               account_number: '123',
               disbursement_description: 'sample disbursement'
             )
-          end.to raise_error XenditApi::Errors::Disbursement::RecipientAccountNumberError
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::Disbursement::RecipientAccountNumberError
+            expect(error.message).to eq 'BCA account numbers must be 10 digits long'
+            expect(error.payload).to eq error_payload
+          end
         end
       end
 
       it 'raise error when got RECIPIENT_AMOUNT_ERROR' do
+        error_payload = { 'error_code' => 'RECIPIENT_AMOUNT_ERROR', 'message' => 'Recipient amount error' }
         VCR.use_cassette('xendit/disbursement/create/recipient_amount_error') do
           disbursement_api = described_class.new(client)
           expect do
@@ -129,11 +150,16 @@ RSpec.describe XenditApi::Api::Disbursement do
               account_number: '1111111111',
               disbursement_description: 'sample disbursement'
             )
-          end.to raise_error XenditApi::Errors::Disbursement::RecipientAmountError
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::Disbursement::RecipientAmountError
+            expect(error.message).to eq 'Recipient amount error'
+            expect(error.payload).to eq error_payload
+          end
         end
       end
 
       it 'raise error when got MAXIMUM_TRANSFER_LIMIT_ERROR' do
+        error_payload = { 'error_code' => 'MAXIMUM_TRANSFER_LIMIT_ERROR', 'message' => 'Maximum transfer limit error' }
         VCR.use_cassette('xendit/disbursement/create/maximum_transfer_limit_error') do
           disbursement_api = described_class.new(client)
           expect do
@@ -145,7 +171,11 @@ RSpec.describe XenditApi::Api::Disbursement do
               account_number: '1111111111',
               disbursement_description: 'sample disbursement'
             )
-          end.to raise_error XenditApi::Errors::Disbursement::MaximumTransferLimitError
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::Disbursement::MaximumTransferLimitError
+            expect(error.message).to eq 'Maximum transfer limit error'
+            expect(error.payload).to eq error_payload
+          end
         end
       end
     end

--- a/spec/xendit_api/api/disbursement_spec.rb
+++ b/spec/xendit_api/api/disbursement_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe XenditApi::Api::Disbursement do
 
     context 'with invalid params' do
       it 'raise errors when bank code not registered' do
+        error_payload = { 'error_code' => 'BANK_CODE_NOT_SUPPORTED_ERROR', 'message' => 'Bank code is not supported' }
         VCR.use_cassette('xendit/disbursement/create/bank_code_not_supported_error') do
           disbursement_api = described_class.new(client)
           expect do
@@ -44,7 +45,11 @@ RSpec.describe XenditApi::Api::Disbursement do
               account_number: '1111111111',
               disbursement_description: 'sample disbursement'
             )
-          end.to raise_error XenditApi::Errors::Disbursement::BankCodeNotSupported, 'Bank code is not supported'
+          end.to raise_error do |error|
+            expect(error).to be_kind_of(XenditApi::Errors::Disbursement::BankCodeNotSupported)
+            expect(error.message).to eq 'Bank code is not supported'
+            expect(error.payload).to eq error_payload
+          end
         end
       end
 

--- a/spec/xendit_api/api/ewallet_spec.rb
+++ b/spec/xendit_api/api/ewallet_spec.rb
@@ -38,11 +38,15 @@ RSpec.describe XenditApi::Api::Ewallet do
 
       it 'raise error phone number not registered' do
         VCR.use_cassette('xendit/ewallet/ovo/errors_invalid_phone_number') do
+          error_payload = { 'error_code' => 'API_VALIDATION_ERROR', 'errors' => [{ 'message' => '"phone" length must be at least 9 characters long', 'path' => ['phone'], 'type' => 'string.min', 'context' => { 'limit' => 9, 'value' => '0', 'key' => 'phone', 'label' => 'phone' } }] }
           expect do
             ewallet_api = described_class.new(client)
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-            # FIXME
-          end.to raise_error(XenditApi::Errors::ApiValidation)
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::ApiValidation
+            expect(error.message).to eq 'Validation error'
+            expect(error.payload).to eq error_payload
+          end
         end
       end
 

--- a/spec/xendit_api/api/ewallet_spec.rb
+++ b/spec/xendit_api/api/ewallet_spec.rb
@@ -70,7 +70,11 @@ RSpec.describe XenditApi::Api::Ewallet do
             ewallet_api = described_class.new(client)
             params = { external_id: '123', amount: 4010, phone: '082310202012' }
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-          end.to raise_error(XenditApi::Errors::OVO::DuplicatePayment, 'There is already payment for the same external ID')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::OVO::DuplicatePayment
+            expect(error.message).to eq 'There is already payment for the same external ID'
+            expect(error.payload).to eq({ 'error_code' => 'DUPLICATE_PAYMENT', 'message' => 'There is already payment for the same external ID' })
+          end
         end
       end
 
@@ -80,7 +84,11 @@ RSpec.describe XenditApi::Api::Ewallet do
             ewallet_api = described_class.new(client)
             params = { external_id: '123', amount: 4020, phone: '082310202012' }
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-          end.to raise_error(XenditApi::Errors::OVO::SendingRequest, 'Error while sending transaction to the e-ewallet provider')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::OVO::SendingRequest
+            expect(error.message).to eq 'Error while sending transaction to the e-ewallet provider'
+            expect(error.payload).to eq({ 'error_code' => 'SENDING_TRANSACTION_ERROR', 'message' => 'Error while sending transaction to the e-ewallet provider' })
+          end
         end
       end
 
@@ -90,7 +98,11 @@ RSpec.describe XenditApi::Api::Ewallet do
             ewallet_api = described_class.new(client)
             params = { external_id: '123', amount: 4030, phone: '082310202012' }
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-          end.to raise_error(XenditApi::Errors::OVO::TransactionDeclined, 'Transaction was declined')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::OVO::TransactionDeclined
+            expect(error.message).to eq 'Transaction was declined'
+            expect(error.payload).to eq({ 'error_code' => 'USER_DECLINED_THE_TRANSACTION', 'message' => 'Transaction was declined' })
+          end
         end
       end
 
@@ -100,7 +112,11 @@ RSpec.describe XenditApi::Api::Ewallet do
             ewallet_api = described_class.new(client)
             params = { external_id: '123', amount: 4040, phone: '087310202012' }
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-          end.to raise_error(XenditApi::Errors::OVO::PhoneNumberNotRegistered, "Phone number is not registered in the e-wallet provider's system")
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::OVO::PhoneNumberNotRegistered
+            expect(error.message).to eq "Phone number is not registered in the e-wallet provider's system"
+            expect(error.payload).to eq({ 'error_code' => 'PHONE_NUMBER_NOT_REGISTERED', 'message' => "Phone number is not registered in the e-wallet provider's system" })
+          end
         end
       end
 
@@ -110,7 +126,11 @@ RSpec.describe XenditApi::Api::Ewallet do
             ewallet_api = described_class.new(client)
             params = { external_id: '123', amount: 4050, phone: '082310202012' }
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-          end.to raise_error(XenditApi::Errors::OVO::EwalletAppUnreacable, 'Your e-wallet app is not reachable by the provider')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::OVO::EwalletAppUnreacable
+            expect(error.message).to eq 'Your e-wallet app is not reachable by the provider'
+            expect(error.payload).to eq({ 'error_code' => 'EWALLET_APP_UNREACHABLE', 'message' => 'Your e-wallet app is not reachable by the provider' })
+          end
         end
       end
 
@@ -120,7 +140,11 @@ RSpec.describe XenditApi::Api::Ewallet do
             ewallet_api = described_class.new(client)
             params = { external_id: '123', amount: 5000, phone: '082310202012' }
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-          end.to raise_error(XenditApi::Errors::OVO::ExternalError, 'External error. Please contact our support')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::OVO::ExternalError
+            expect(error.message).to eq 'External error. Please contact our support'
+            expect(error.payload).to eq({ 'error_code' => 'EXTERNAL_ERROR', 'message' => 'External error. Please contact our support' })
+          end
         end
       end
 
@@ -130,7 +154,11 @@ RSpec.describe XenditApi::Api::Ewallet do
             ewallet_api = described_class.new(client)
             params = { external_id: '123', amount: 9999, phone: '082310202299' }
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-          end.to raise_error(XenditApi::Errors::UnknownError, 'Unknown error was triggered')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::UnknownError
+            expect(error.message).to eq 'Unknown error was triggered'
+            expect(error.payload).to eq({ 'error_code' => 'UNKNOWN_ERROR', 'message' => 'Unknown error was triggered' })
+          end
         end
       end
     end
@@ -159,7 +187,11 @@ RSpec.describe XenditApi::Api::Ewallet do
           expect do
             ewallet_api = described_class.new(client)
             ewallet_api.get(external_id: nil)
-          end.to raise_error(XenditApi::Errors::OVO::PaymentNotFound, 'Payment not found')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::OVO::PaymentNotFound
+            expect(error.message).to eq 'Payment not found'
+            expect(error.payload).to eq({ 'error_code' => 'PAYMENT_NOT_FOUND_ERROR', 'message' => 'Payment not found' })
+          end
         end
       end
     end

--- a/spec/xendit_api/api/ewallet_spec.rb
+++ b/spec/xendit_api/api/ewallet_spec.rb
@@ -56,7 +56,11 @@ RSpec.describe XenditApi::Api::Ewallet do
             ewallet_api = described_class.new(client)
             params = { external_id: '123', amount: 4000, phone: '082310202012' }
             ewallet_api.post(params: params, ewallet_type: 'OVO')
-          end.to raise_error(XenditApi::Errors::OVO::PaymentTimeout, 'Payment was not authorized')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::OVO::PaymentTimeout
+            expect(error.message).to eq 'Payment was not authorized'
+            expect(error.payload).to eq({ 'error_code' => 'USER_DID_NOT_AUTHORIZE_THE_PAYMENT', 'message' => 'Payment was not authorized' })
+          end
         end
       end
 

--- a/spec/xendit_api/api/v1/ewallet_spec.rb
+++ b/spec/xendit_api/api/v1/ewallet_spec.rb
@@ -74,7 +74,11 @@ RSpec.describe XenditApi::Api::V1::Ewallet do
             ewallet_api = described_class.new(client)
             params = { reference_id: '7f156109-5f7a-479a-84db-f59c5ab38766', amount: 10_101, mobile_number: '+6282310202012' }
             ewallet_api.post(params: params, payment_method: :ovo)
-          end.to raise_error(XenditApi::Errors::V1::Ewallet::ChannelUnavailable)
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::V1::Ewallet::ChannelUnavailable
+            expect(error.message).to eq 'The payment channel requested is currently experiencing unexpected issues. The eWallet provider will be notified to resolve this issue.'
+            expect(error.payload).to eq({ 'error_code' => 'CHANNEL_UNAVAILABLE', 'message' => 'The payment channel requested is currently experiencing unexpected issues. The eWallet provider will be notified to resolve this issue.' })
+          end
         end
       end
 
@@ -84,7 +88,11 @@ RSpec.describe XenditApi::Api::V1::Ewallet do
             ewallet_api = described_class.new(client)
             params = { reference_id: '434c9cc3-72ab-4ec0-82ba-488d040c15c1', amount: 10_102, mobile_number: '+6282310202012' }
             ewallet_api.post(params: params, payment_method: :ovo)
-          end.to raise_error(XenditApi::Errors::ServerError)
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::ServerError
+            expect(error.message).to eq 'An unexpected error occurred, our team has been notified and will troubleshoot the issue.'
+            expect(error.payload).to eq({ 'error_code' => 'SERVER_ERROR', 'message' => 'An unexpected error occurred, our team has been notified and will troubleshoot the issue.' })
+          end
         end
       end
 
@@ -94,7 +102,11 @@ RSpec.describe XenditApi::Api::V1::Ewallet do
             ewallet_api = described_class.new(client)
             params = { reference_id: 'eacd7788-8864-421c-a39c-9c59c3ee875c', amount: 4000, mobile_number: '+6282310202012' }
             ewallet_api.post(params: params, payment_method: :ovo)
-          end.to raise_error(XenditApi::Errors::V1::Ewallet::DuplicateError, 'There is already a charge request with the same reference_id.')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::V1::Ewallet::DuplicateError
+            expect(error.message).to eq 'There is already a charge request with the same reference_id.'
+            expect(error.payload).to eq({ 'error_code' => 'DUPLICATE_ERROR', 'message' => 'There is already a charge request with the same reference_id.' })
+          end
         end
       end
 
@@ -104,7 +116,11 @@ RSpec.describe XenditApi::Api::V1::Ewallet do
             ewallet_api = described_class.new(client)
             params = { reference_id: '307e9c34-7fed-45fe-b6d6-1f77bbbe872e', amount: 9999, mobile_number: '+6282310202299' }
             ewallet_api.post(params: params, payment_method: :ovo)
-          end.to raise_error(XenditApi::Errors::UnknownError, 'Unknown error was triggered')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::UnknownError
+            expect(error.message).to eq 'Unknown error was triggered'
+            expect(error.payload).to eq({ 'error_code' => 'UNKNOWN', 'message' => 'Unknown error was triggered' })
+          end
         end
       end
     end
@@ -135,7 +151,11 @@ RSpec.describe XenditApi::Api::V1::Ewallet do
             ewallet_api = described_class.new(client)
             random_uuid = 'ewc_d351c488-fd5c-4a41-975f-f94614f7628f'
             ewallet_api.get(random_uuid)
-          end.to raise_error(XenditApi::Errors::V1::Ewallet::DataNotFound, 'Charge request not found')
+          end.to raise_error do |error|
+            expect(error).to be_kind_of XenditApi::Errors::V1::Ewallet::DataNotFound
+            expect(error.message).to eq 'Charge request not found'
+            expect(error.payload).to eq({ 'error_code' => 'DATA_NOT_FOUND', 'message' => 'Charge request not found' })
+          end
         end
       end
     end

--- a/spec/xendit_api/api/virtual_account_spec.rb
+++ b/spec/xendit_api/api/virtual_account_spec.rb
@@ -313,11 +313,21 @@ RSpec.describe XenditApi::Api::VirtualAccount do
             amount: 500_000,
             bank_code: 'RANDOM_BANK_CODE'
           )
-        end.to raise_error XenditApi::Errors::VirtualAccount::BankNotSupported
+        end.to raise_error do |error|
+          expect(error).to be_kind_of XenditApi::Errors::VirtualAccount::BankNotSupported
+          expect(error.message).to eq 'That bank code is not currently supported'
+          expect(error.payload).to eq({ 'error_code' => 'BANK_NOT_SUPPORTED_ERROR', 'message' => 'That bank code is not currently supported' })
+        end
       end
     end
 
     it 'raises API_VALIDATION_ERROR when external_id, name, amount was blank' do
+      error_payload = { 'error_code' => 'API_VALIDATION_ERROR',
+                        'message' => 'There was an error with the format submitted to the server.',
+                        'errors' =>
+         [{ 'field' => ['external_id'], 'location' => 'body', 'messages' => ['"external_id" must be a string'], 'types' => ['string.base'] },
+          { 'field' => ['name'], 'location' => 'body', 'messages' => ['"name" must be a string'], 'types' => ['string.base'] },
+          { 'field' => ['expected_amount'], 'location' => 'body', 'messages' => ['"expected_amount" must be a number'], 'types' => ['number.base'] }] }
       VCR.use_cassette('xendit/virtual_account/raise_api_validation') do
         virtual_account_api = described_class.new(client)
         expect do
@@ -327,7 +337,11 @@ RSpec.describe XenditApi::Api::VirtualAccount do
             amount: nil,
             bank_code: 'MANDIRI'
           )
-        end.to raise_error XenditApi::Errors::ApiValidation
+        end.to raise_error do |error|
+          expect(error).to be_kind_of XenditApi::Errors::ApiValidation
+          expect(error.message).to eq 'Validation error'
+          expect(error.payload).to eq error_payload
+        end
       end
     end
 
@@ -341,7 +355,11 @@ RSpec.describe XenditApi::Api::VirtualAccount do
             amount: 0,
             bank_code: 'MANDIRI'
           )
-        end.to raise_error XenditApi::Errors::VirtualAccount::MinimumExpectedAmount
+        end.to raise_error do |error|
+          expect(error).to be_kind_of XenditApi::Errors::VirtualAccount::MinimumExpectedAmount
+          expect(error.message).to eq 'The minimum Expected Amount for MANDIRI VA is 1'
+          expect(error.payload).to eq({ 'error_code' => 'MINIMUM_EXPECTED_AMOUNT_ERROR', 'message' => 'The minimum Expected Amount for MANDIRI VA is 1' })
+        end
       end
     end
 
@@ -355,7 +373,11 @@ RSpec.describe XenditApi::Api::VirtualAccount do
             amount: 50_000_000_001,
             bank_code: 'MANDIRI'
           )
-        end.to raise_error XenditApi::Errors::VirtualAccount::MaximumExpectedAmount
+        end.to raise_error do |error|
+          expect(error).to be_kind_of XenditApi::Errors::VirtualAccount::MaximumExpectedAmount
+          expect(error.message).to eq 'The maximum Expected Amount for MANDIRI VA is 50000000000'
+          expect(error.payload).to eq({ 'error_code' => 'MAXIMUM_EXPECTED_AMOUNT_ERROR', 'message' => 'The maximum Expected Amount for MANDIRI VA is 50000000000' })
+        end
       end
     end
   end
@@ -449,7 +471,11 @@ RSpec.describe XenditApi::Api::VirtualAccount do
         }
         expect do
           virtual_account_api.update(create_response.id, params)
-        end.to raise_error XenditApi::Errors::VirtualAccount::MinimumExpectedAmount, 'The minimum Expected Amount for MANDIRI VA is 1'
+        end.to raise_error do |error|
+          expect(error).to be_kind_of XenditApi::Errors::VirtualAccount::MinimumExpectedAmount
+          expect(error.message).to eq 'The minimum Expected Amount for MANDIRI VA is 1'
+          expect(error.payload).to eq({ 'error_code' => 'MINIMUM_EXPECTED_AMOUNT_ERROR', 'message' => 'The minimum Expected Amount for MANDIRI VA is 1' })
+        end
       end
     end
   end

--- a/spec/xendit_api/model/disbursement_spec.rb
+++ b/spec/xendit_api/model/disbursement_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+RSpec.describe XenditApi::Model::Disbursement do
+  it 'returns expected disbursement' do
+    disbursement = described_class.new(external_id: 'hello', amount: 500_000)
+    expect(disbursement.external_id).to eq 'hello'
+    expect(disbursement.amount).to eq 500_000
+  end
+
+  it 'returns expected disbursement when there is new undefined attribute' do
+    disbursement = described_class.new(external_id: 'hello', hello: 'world')
+    expect(disbursement.external_id).to eq 'hello'
+  end
+end


### PR DESCRIPTION
## Summary

Currently, there is no way for clients, if they want to show a full error response from Xendit, instead we just throw the Exception class with the simple title string.

This PR is to give the client the ability to see the full error response, now client could see that like this:

```rb
  client = XenditApi::Client.new('secret-key')
  client.disbursement.create(params)
rescue XenditApi::Errors::ResponseError => e
  puts e.mesage #> 'Recipient amount error'
  puts e.payload #> { 'error_code' => 'RECIPIENT_AMOUNT_ERROR', 'message' => 'Recipient amount error' }
``` 

You could now access the full response via `#payload` and return a `Hash`. 

Another work is adding a new attribute `#is_instant` in the `Disbursement` model and making the private `#assign_attributes` in Base Model only assign the defined resource attributes, currently, there is an error when there is a new attribute in Xendit Api response that we don't define in the model. 

### Additional note

There is new config in rubocop.yml 

```yml
Style/MultilineBlockChain:
  Enabled: false
```

This config is needed since when want to test the payload of the exception class we need `MultilineBlockChain` style, since RSpec use that style, you could see the reference here: https://relishapp.com/rspec/rspec-expectations/v/2-8/docs/built-in-matchers/raise-error-matcher#set-expectations-on-error-object-passed-to-block
