### PR TITLE
Make the Exception message to be optional

### DIFF
--- a/lib/xendit_api/errors.rb
+++ b/lib/xendit_api/errors.rb
@@ -3,10 +3,10 @@ module XenditApi
     class ResponseError < StandardError
       attr_reader :payload
 
-      def initialize(message, payload = nil)
+      def initialize(message = nil, payload = nil)
         @message = message
         @payload = payload
-        super(@message)
+        super(@message) unless @message.nil?
       end
     end
 

--- a/spec/xendit_api/errors/credit_card_spec.rb
+++ b/spec/xendit_api/errors/credit_card_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe XenditApi::Errors::CreditCard do
+  describe 'ResponseError' do
+    it 'is expected parent class' do
+      expect(described_class::ResponseError.superclass).to eq(XenditApi::Errors::ResponseError)
+    end
+  end
+
+  describe 'ChargeError' do
+    it 'is expected parent class' do
+      expect(described_class::ChargeError.superclass).to eq(XenditApi::Errors::CreditCard::ResponseError)
+    end
+  end
+
+  describe 'CardDeclined' do
+    it 'is expected parent class' do
+      expect(described_class::CardDeclined.superclass).to eq(XenditApi::Errors::CreditCard::ResponseError)
+    end
+
+    it 'is returns expected message' do
+      expect do
+        raise described_class::CardDeclined
+      end.to raise_error described_class::CardDeclined, 'The card you are trying to capture has been declined by the issuing bank.'
+    end
+  end
+
+  describe 'ExpiredCard' do
+    it 'is expected parent class' do
+      expect(described_class::ExpiredCard.superclass).to eq(XenditApi::Errors::CreditCard::ResponseError)
+    end
+  end
+
+  describe 'InsufficientBalance' do
+    it 'is expected parent class' do
+      expect(described_class::InsufficientBalance.superclass).to eq(XenditApi::Errors::CreditCard::ResponseError)
+    end
+  end
+
+  describe 'StolenCard' do
+    it 'is expected parent class' do
+      expect(described_class::StolenCard.superclass).to eq(XenditApi::Errors::CreditCard::ResponseError)
+    end
+  end
+
+  describe 'InactiveCard' do
+    it 'is expected parent class' do
+      expect(described_class::InactiveCard.superclass).to eq(XenditApi::Errors::CreditCard::ResponseError)
+    end
+  end
+
+  describe 'InvalidCvn' do
+    it 'is expected parent class' do
+      expect(described_class::InvalidCvn.superclass).to eq(XenditApi::Errors::CreditCard::ResponseError)
+    end
+  end
+end

--- a/spec/xendit_api/errors/response_error_spec.rb
+++ b/spec/xendit_api/errors/response_error_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+RSpec.describe XenditApi::Errors::ResponseError do
+  it 'could raise expected error without any argument' do
+    expect do
+      raise described_class
+    end.to raise_error described_class
+  end
+
+  it 'could raise expected error with one argument' do
+    expect do
+      raise described_class, 'The charge error'
+    end.to raise_error described_class, 'The charge error'
+  end
+
+  it 'could raise expected error with two argument' do
+    expect do
+      raise described_class.new('The charge error', { payload: 'hello' })
+    end.to raise_error do |error|
+      expect(error).to be_kind_of described_class
+      expect(error.message).to eq 'The charge error'
+      expect(error.payload).to eq({ payload: 'hello' })
+    end
+  end
+end


### PR DESCRIPTION
## Summary

After this PR gets merged https://github.com/mekari-engineering/xendit_api/pull/13, you should raise an exception with the required message, and it will error if you want to raise without a message like this:

```sh
$ bundle console
irb: warn: can't alias context from irb_context.
irb(main):001:0> raise XenditApi::Errors::CreditCard::ChargeError
/Users/philiplambok/Codes/ruby/xendit_api/lib/xendit_api/errors.rb:6:in `initialize': wrong number of arguments (given 0, expected 1..2) (ArgumentError)
```

Instead you should do like this:

```sh
$ bundle console
irb(main):002:0> raise XenditApi::Errors::CreditCard::ChargeError, "Charge Error"
(irb):2:in `<main>': Charge Error (XenditApi::Errors::CreditCard::ChargeError)
```

But, in the current situation, there is a client that called the ExceptionError class (CreditCard) directly without a message, so it's will be an error when want to use the current update of this API.

So, the purpose of this PR is make the client could raise the (all) defined errors class in this API without required message like this:

```sh
$ bundle console
irb: warn: can't alias context from irb_context.
irb(main):001:0> raise XenditApi::Errors::CreditCard::ChargeError
(irb):1:in `<main>': XenditApi::Errors::CreditCard::ChargeError (XenditApi::Errors::CreditCard::ChargeError)
```